### PR TITLE
Ensure accounts in transactions can start with all letters

### DIFF
--- a/syntaxes/beancount.tmLanguage
+++ b/syntaxes/beancount.tmLanguage
@@ -837,7 +837,7 @@
 		<key>flag</key>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;=\s)([*!&amp;amp;#?%PSTCURM])</string>
+			<string>(?&lt;=\s)([*!&amp;amp;#?%PSTCURM])(?=\s+)</string>
 			<key>name</key>
 			<string>keyword.other.beancount</string>
 		</dict>


### PR DESCRIPTION
Previously, accounts that started with one of the `PSTCURM` characters weren't highlighted correctly in transactions.

This ensures that flags only match if they are succeeded by a whitespace character.

Before:
<img width="507" alt="image" src="https://user-images.githubusercontent.com/18848/61002339-a2ccd980-a361-11e9-9f64-4a609648381b.png">

After:
<img width="508" alt="image" src="https://user-images.githubusercontent.com/18848/61002296-8af55580-a361-11e9-9880-d8133d4ba75a.png">
<img width="502" alt="image" src="https://user-images.githubusercontent.com/18848/61002390-bed07b00-a361-11e9-90b2-d1d51e095e21.png">
<img width="506" alt="image" src="https://user-images.githubusercontent.com/18848/61002403-c55ef280-a361-11e9-89fd-662feb347c32.png">


